### PR TITLE
Replace random element ID to reference

### DIFF
--- a/src/AceEditor.svelte
+++ b/src/AceEditor.svelte
@@ -2,9 +2,6 @@
   import { createEventDispatcher, tick, onMount, onDestroy } from "svelte";
   import * as ace from "brace";
   import "brace/ext/emmet";
-  const EDITOR_ID = `svelte-ace-editor-div:${Math.floor(
-    Math.random() * 10000000000
-  )}`;
   const dispatch = createEventDispatcher<{
     init: ace.Editor;
     input: string;
@@ -31,7 +28,7 @@
   export let width: string = "100%"; // null for 100, else integer, used as percent
   export let options: any = {}; // Object
   export let readonly: boolean = false;
-
+  let editorElement: HTMLElement;
   let editor: ace.Editor;
   let contentBackup: string = "";
 
@@ -96,7 +93,7 @@
     lang = lang || "text";
     theme = theme || "chrome";
 
-    editor = ace.edit(EDITOR_ID);
+    editor = ace.edit(editorElement);
 
     dispatch("init", editor);
     editor.$blockScrolling = Infinity;
@@ -152,5 +149,5 @@
 </script>
 
 <div style="width:{px(width)};height:{px(height)}">
-  <div id={EDITOR_ID} style="width:{px(width)};height:{px(height)}" />
+  <div bind:this={editorElement} style="width:{px(width)};height:{px(height)}" />
 </div>


### PR DESCRIPTION
Link to DOM element without relying on possible ID collision.

Refs

* [how to bind DOM element in Svelte](https://svelte.dev/docs#bind_element)
* [ace constructor supports element as parameter](https://ace.c9.io/#nav=api&api=ace)